### PR TITLE
Update jsxstyle, reset cache for each render

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "jest-diff": "^19.0.0",
     "jest-snapshot": "^19.0.2",
-    "jsxstyle": "2.0.0-beta.3"
+    "jsxstyle": "2.0.0-beta.6"
   },
   "devDependencies": {
     "babel-cli": "^6.23.0",

--- a/src/__snapshots__/serializer.test.js.snap
+++ b/src/__snapshots__/serializer.test.js.snap
@@ -53,6 +53,8 @@ exports[`Snapshot Serializer works when root element is not a jsxstyle element 1
 `;
 
 exports[`enzyme.mount 1`] = `
+._1cvnte8 {color:green;display:block;}
+._15clmrq {display:block;margin:4rem;}
 
 
 <Block
@@ -77,6 +79,8 @@ exports[`enzyme.mount 1`] = `
 `;
 
 exports[`enzyme.render 1`] = `
+._1cvnte8 {color:green;display:block;}
+._15clmrq {display:block;margin:4rem;}
 
 
 <div

--- a/src/serializer.js
+++ b/src/serializer.js
@@ -1,4 +1,4 @@
-const { injectAddRule, resetCache } = require('jsxstyle/lib/styleCache');
+const { injectAddRule, resetCache } = require('jsxstyle');
 
 let styles = '';
 injectAddRule(rule => (styles += rule + '\n'));
@@ -16,7 +16,7 @@ function createSerializer(injector) {
     const prettyPrinted = `${styles}\n\n${printer(val)}`;
 
     styles = '';
-    // resetCache() per test??
+    resetCache();
     return prettyPrinted;
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2211,9 +2211,9 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.3.6"
 
-jsxstyle@2.0.0-beta.3:
-  version "2.0.0-beta.3"
-  resolved "https://registry.yarnpkg.com/jsxstyle/-/jsxstyle-2.0.0-beta.3.tgz#dd732862791ff6d6a70996bf4306c2b392dd7343"
+jsxstyle@2.0.0-beta.6:
+  version "2.0.0-beta.6"
+  resolved "https://registry.yarnpkg.com/jsxstyle/-/jsxstyle-2.0.0-beta.6.tgz#bfb38e4d9018ecdddfd76c1899cbf7b783e34e7a"
   dependencies:
     invariant "^2.2.1"
     prop-types "^15.5.8"


### PR DESCRIPTION
This updates jsxstyle to 2.0.0-beta.6, which exposes `injectAddRule` and `resetCache`, and makes it so that `resetCache` is fired with each print. This looks like it also fixed the snapshots for the enzyme test.

Also, this isn't strictly related to this PR, but I was wondering if jsxstyle should be a peer dependency, as it seems like our snapshot tests wouldn't work as long as the version of jsxstyle in this package differed from the one we were using in our project.