### PR TITLE
Update for jsxstyle 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "jest-diff": "^19.0.0",
     "jest-snapshot": "^19.0.2",
-    "jsxstyle": "2.0.0-beta.6"
+    "jsxstyle": "2.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.23.0",

--- a/src/__snapshots__/serializer.test.js.snap
+++ b/src/__snapshots__/serializer.test.js.snap
@@ -9,8 +9,14 @@ exports[`Snapshot Serializer does not interfere with non jsxstyle components 1`]
 `;
 
 exports[`Snapshot Serializer handles children 1`] = `
-._1jmy8or {color:orange;display:block;}
-._15clmrq {display:block;margin:4rem;}
+._1jmy8or {
+  color: orange;
+  display: block;
+}
+._15clmrq {
+  display: block;
+  margin: 4rem;
+}
 
 
 <div
@@ -27,7 +33,12 @@ exports[`Snapshot Serializer handles children 1`] = `
 `;
 
 exports[`Snapshot Serializer react-test-renderer 1`] = `
-._1d79ojo {background:white;color:red;display:block;margin:1rem;}
+._1d79ojo {
+  background: white;
+  color: red;
+  display: block;
+  margin: 1rem;
+}
 
 
 <div
@@ -39,7 +50,10 @@ exports[`Snapshot Serializer react-test-renderer 1`] = `
 `;
 
 exports[`Snapshot Serializer works when root element is not a jsxstyle element 1`] = `
-._18ai6h8 {color:black;display:block;}
+._18ai6h8 {
+  color: black;
+  display: block;
+}
 
 
 <div>
@@ -53,8 +67,14 @@ exports[`Snapshot Serializer works when root element is not a jsxstyle element 1
 `;
 
 exports[`enzyme.mount 1`] = `
-._1cvnte8 {color:green;display:block;}
-._15clmrq {display:block;margin:4rem;}
+._1cvnte8 {
+  color: green;
+  display: block;
+}
+._15clmrq {
+  display: block;
+  margin: 4rem;
+}
 
 
 <Block
@@ -79,8 +99,14 @@ exports[`enzyme.mount 1`] = `
 `;
 
 exports[`enzyme.render 1`] = `
-._1cvnte8 {color:green;display:block;}
-._15clmrq {display:block;margin:4rem;}
+._1cvnte8 {
+  color: green;
+  display: block;
+}
+._15clmrq {
+  display: block;
+  margin: 4rem;
+}
 
 
 <div
@@ -95,7 +121,10 @@ exports[`enzyme.render 1`] = `
 `;
 
 exports[`enzyme.shallow 1`] = `
-._1cvnte8 {color:green;display:block;}
+._1cvnte8 {
+  color: green;
+  display: block;
+}
 
 
 <div

--- a/src/serializer.js
+++ b/src/serializer.js
@@ -1,7 +1,13 @@
-const { injectAddRule, resetCache } = require('jsxstyle');
+const { cache } = require('jsxstyle');
 
 let styles = '';
-injectAddRule(rule => (styles += rule + '\n'));
+
+cache.injectOptions({
+  onInsertRule: rule => {
+    styles += rule + '\n';
+  },
+  pretty: true
+})
 
 function createSerializer(injector) {
   function test(val) {
@@ -16,7 +22,7 @@ function createSerializer(injector) {
     const prettyPrinted = `${styles}\n\n${printer(val)}`;
 
     styles = '';
-    resetCache();
+    cache.reset();
     return prettyPrinted;
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1396,18 +1396,6 @@ fbjs@^0.8.1, fbjs@^0.8.4:
     setimmediate "^1.0.5"
     ua-parser-js "^0.7.9"
 
-fbjs@^0.8.9:
-  version "0.8.14"
-  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.14.tgz#d1dbe2be254c35a91e09f31f9cd50a40b2a0ed1c"
-  dependencies:
-    core-js "^1.0.0"
-    isomorphic-fetch "^2.1.1"
-    loose-envify "^1.0.0"
-    object-assign "^4.1.0"
-    promise "^7.1.1"
-    setimmediate "^1.0.5"
-    ua-parser-js "^0.7.9"
-
 figures@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-1.7.0.tgz#cbe1e3affcf1cd44b80cadfed28dc793a9701d2e"
@@ -2211,12 +2199,18 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.3.6"
 
-jsxstyle@2.0.0-beta.6:
-  version "2.0.0-beta.6"
-  resolved "https://registry.yarnpkg.com/jsxstyle/-/jsxstyle-2.0.0-beta.6.tgz#bfb38e4d9018ecdddfd76c1899cbf7b783e34e7a"
+jsxstyle-utils@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/jsxstyle-utils/-/jsxstyle-utils-2.0.0.tgz#211a4d113bd2ed3ce2a27072f97bcc9179333f69"
   dependencies:
     invariant "^2.2.1"
-    prop-types "^15.5.8"
+
+jsxstyle@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/jsxstyle/-/jsxstyle-2.0.0.tgz#5d032edbd10a9b585a477b365cd19d3edec1d0fc"
+  dependencies:
+    invariant "^2.2.1"
+    jsxstyle-utils "^2.0.0"
 
 kind-of@^3.0.2:
   version "3.1.0"
@@ -2405,7 +2399,7 @@ longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
 
-loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1:
+loose-envify@^1.0.0, loose-envify@^1.1.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
   dependencies:
@@ -2820,13 +2814,6 @@ promise@^7.1.1:
   resolved "https://registry.yarnpkg.com/promise/-/promise-7.1.1.tgz#489654c692616b8aa55b0724fa809bb7db49c5bf"
   dependencies:
     asap "~2.0.3"
-
-prop-types@^15.5.8:
-  version "15.5.10"
-  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.10.tgz#2797dfc3126182e3a95e3dfbb2e893ddd7456154"
-  dependencies:
-    fbjs "^0.8.9"
-    loose-envify "^1.3.1"
 
 prr@~0.0.0:
   version "0.0.0"


### PR DESCRIPTION
Updates this package for the API of jest-jsxstyle@2.0.0, which now exports a cache object with its own API for resetting and adding injection rules.

Also makes it so that the serialised CSS rules are pretty printed, which IMO makes them easier to read and look at diffs for.